### PR TITLE
feat: add dummy data seeders for categories and products

### DIFF
--- a/be-pangalengan/database/seeders/CategorySeeder.php
+++ b/be-pangalengan/database/seeders/CategorySeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Category;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+        Category::insert([
+            [
+                'id' => 1,
+                'name' => 'Coffe Dummy 1',
+                'slug' => 'espresso',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+
+            [
+                'id' => 2,
+                'name' => 'Coffe Dummy 2',
+                'slug' => 'latte',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+
+            [
+                'id' => 3,
+                'name' => 'Coffe Dummy 3',
+                'slug' => 'cappucino',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+
+        ]);
+    }
+}

--- a/be-pangalengan/database/seeders/ProductSeeder.php
+++ b/be-pangalengan/database/seeders/ProductSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+Use App\Models\Product;
+
+class ProductSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+        Product::insert([
+            [
+                'name' => 'Coffe Dummy 1',
+                'description' => 'Description Coffe 1',
+                'price' => '80000',
+                'image' => 'http://wallup.net/wp-content/uploads/2017/11/17/239445-coffee-coffee_beans-cup.jpg',
+                'category_id' => '1',
+            ], 
+
+            [
+                'name' => 'Coffe Dummy 2',
+                'description' => 'Description Coffe 2',
+                'price' => '100000',
+                'image' => 'https://www.tastingtable.com/img/gallery/coffee-brands-ranked-from-worst-to-best/l-intro-1645231221.jpg',
+                'category_id' => '2',
+            ],
+
+            [
+                'name' => 'Coffe Dummy 3',
+                'description' => 'Description Coffe 3',
+                'price' => '150000',
+                'image' => 'https://neurosciencenews.com/files/2023/06/coffee-brain-caffeine-neuroscincces.jpg',
+                'category_id' => '3',
+            ]
+            
+
+        ]);
+    }
+}


### PR DESCRIPTION
Menambahkan kelas seeder untuk mengisi tabel 'categories' dan 'products' dengan data dummy.

Perubahan yang Dilakukan:
- Membuat 'CategorySeeder' dengan 3 contoh kategori
- Membuat 'ProductSeeder' dengan contoh produk yang ditautkan ke kategori
- Memperbarui 'DatabaseSeeder' untuk menyertakan kedua seeder


Tujuan:
Untuk mendukung pengembangan frontend dengan menyediakan data dummy untuk pengujian dan integrasi UI. Ini menghindari kebutuhan untuk memasukkan catatan secara manual untuk kategori dan produk.

Pengujian:
- Jalankan `php artisan migrate:fresh --seed` untuk mengatur ulang dan mengisi database
- Konfirmasikan data ada di tabel `categories` dan `products`